### PR TITLE
Add option to disable invalidate cache for all if wanted

### DIFF
--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -52,9 +52,9 @@ module LinkedData
           return administeredBy.any? {|u| u == user.id}
         end
 
-        def invalidate_cache
+        def invalidate_cache(cache_refresh_all = true)
           self.class.all(invalidate_cache: true, include_views: true)
-          super
+          super(cache_refresh_all)
         end
 
         # ACL with administrators

--- a/lib/ontologies_api_client/models/user.rb
+++ b/lib/ontologies_api_client/models/user.rb
@@ -20,7 +20,7 @@ module LinkedData
           respond_to?(:role) && role.include?("ADMINISTRATOR")
         end
 
-        def invalidate_cache
+        def invalidate_cache(cache_refresh_all = true)
           super
           ## IMPORTANT
           # We have to invalidate ontologies here because the user could be setting

--- a/lib/ontologies_api_client/models/user.rb
+++ b/lib/ontologies_api_client/models/user.rb
@@ -21,7 +21,7 @@ module LinkedData
         end
 
         def invalidate_cache(cache_refresh_all = true)
-          super
+          super(cache_refresh_all)
           ## IMPORTANT
           # We have to invalidate ontologies here because the user could be setting
           # custom ontologies. If we don't do this both on the REST and here then

--- a/lib/ontologies_api_client/read_write.rb
+++ b/lib/ontologies_api_client/read_write.rb
@@ -5,18 +5,14 @@ module LinkedData
     module ReadWrite
       HTTP = LinkedData::Client::HTTP
 
-      def save
+      def save(options = {})
         resp = HTTP.post(self.class.collection_path, self.to_hash)
-=begin
-        options = {}
         if options[:cache_refresh_all] == false
           # cache_refresh_all allow to avoid to refresh everything, to make it faster when saving new submission
           invalidate_cache(false)
         else
           invalidate_cache(true)
         end
-=end
-        invalidate_cache()
         resp
       end
 

--- a/lib/ontologies_api_client/read_write.rb
+++ b/lib/ontologies_api_client/read_write.rb
@@ -7,12 +7,8 @@ module LinkedData
 
       def save(options = {})
         resp = HTTP.post(self.class.collection_path, self.to_hash)
-        if options[:cache_refresh_all] == false
-          # cache_refresh_all allow to avoid to refresh everything, to make it faster when saving new submission
-          invalidate_cache(false)
-        else
-          invalidate_cache(true)
-        end
+        # cache_refresh_all allow to avoid to refresh everything, to make it faster when saving new submission
+        invalidate_cache(options[:cache_refresh_all] == false)
         resp
       end
 
@@ -20,12 +16,9 @@ module LinkedData
         values = options[:values] || changed_values()
         return if values.empty?
         resp = HTTP.patch(self.id, values)
-        if options[:cache_refresh_all] == false
-          # When updating submission we avoid refreshing all cache to avoid calling /submissions?display=all that takes a lot of time
-          invalidate_cache(false)
-        else
-          invalidate_cache(true)
-        end
+        # When updating submission we avoid refreshing all cache to avoid calling /submissions?display=all that takes a lot of time
+        invalidate_cache(options[:cache_refresh_all] == false)
+
         resp
       end
 
@@ -91,9 +84,7 @@ module LinkedData
       end
 
       def invalidate_cache(cache_refresh_all = true)
-        if cache_refresh_all
-          self.class.all(invalidate_cache: true)
-        end
+        self.class.all(invalidate_cache: true) if cache_refresh_all
         HTTP.get(self.id, invalidate_cache: true) if self.id
         session = Thread.current[:session]
         session[:last_updated] = Time.now.to_f if session


### PR DESCRIPTION
We had this issue https://github.com/agroportal/documentation/issues/190 at Agroportal

And it was caused by **Timeout due to the function [invalidate cache](https://github.com/ncbo/ontologies_api_ruby_client/blob/master/lib/ontologies_api_client/read_write.rb#L83) when adding or updating a submission**, see the fullstack trace below
```
F, [2022-02-11T12:31:57.620895 #31058] FATAL -- : Faraday::TimeoutError (Problem retrieving:
http://data.agroportal.lirmm.fr/submissions?include=all&include_status=READY
Error: read timeout reached
/srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/socket.rb:286:in `select_with_timeout'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/socket.rb:196:in `rescue in read_nonblock'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/socket.rb:177:in `read_nonblock'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/socket.rb:65:in `readline'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/response.rb:64:in `block in parse'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/response.rb:63:in `loop'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/response.rb:63:in `parse'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/middlewares/response_parser.rb:7:in `response_call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/connection.rb:456:in `response'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/excon-0.91.0/lib/excon/connection.rb:287:in `request'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-excon-1.1.0/lib/faraday/adapter/excon.rb:31:in `block in call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/adapter.rb:53:in `connection'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-excon-1.1.0/lib/faraday/adapter/excon.rb:31:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/request/url_encoded.rb:25:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/request/multipart.rb:30:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/middleware/faraday-object-cache.rb:63:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/middleware/faraday-last-updated.rb:16:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/middleware/faraday-slices.rb:16:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/middleware/faraday-user-apikey.rb:16:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/rack_builder.rb:154:in `build_response'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/connection.rb:495:in `run_request'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/faraday-1.4.3/lib/faraday/connection.rb:199:in `get'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/http.rb:63:in `get'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/collection.rb:43:in `entry_point'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/collection.rb:56:in `all'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/models/ontology_submission.rb:28:in `all'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/read_write.rb:95:in `invalidate_cache'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/bundler/gems/ontologies_api_ruby_client-3e9e1fa7c199/lib/ontologies_api_client/read_write.rb:14:in `save'
        /srv/ontoportal/bioportal_web_ui/releases/20220210085106/app/controllers/submissions_controller.rb:45:in `create'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/abstract_controller/base.rb:194:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/rendering.rb:30:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:132:in `run_callbacks'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/abstract_controller/callbacks.rb:41:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/rescue.rb:22:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `block in instrument'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `instrument'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activerecord-5.2.6/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/abstract_controller/base.rb:134:in `process'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionview-5.2.6/lib/action_view/rendering.rb:32:in `process'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal.rb:191:in `dispatch'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_controller/metal.rb:252:in `dispatch'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:34:in `serve'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:52:in `block in serve'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `each'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `serve'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:840:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/turnout-2.5.0/lib/rack/turnout.rb:25:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/conditional_get.rb:40:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/cookies.rb:670:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:98:in `run_callbacks'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:38:in `call_app'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:26:in `block in call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:71:in `block in tagged'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:28:in `tagged'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:71:in `tagged'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:26:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/request_id.rb:27:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.6/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/executor.rb:14:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/rack-mini-profiler-2.3.3/lib/mini_profiler/profiler.rb:249:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/engine.rb:524:in `call'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `public_send'
        /srv/ontoportal/bioportal_web_ui/shared/bundle/ruby/2.6.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `method_missing'
        /usr/share/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:107:in `process_request'
        /usr/share/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:157:in `accept_and_process_next_request'
        /usr/share/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:110:in `main_loop'
        /usr/share/ruby/vendor_ruby/phusion_passenger/request_handler.rb:419:in `block (3 levels) in start_threads'
        /usr/share/ruby/vendor_ruby/phusion_passenger/utils.rb:113:in `block in create_thread_and_abort_on_exception'):
F, [2022-02-11T12:31:57.621145 #31058] FATAL -- :   
F, [2022-02-11T12:31:57.621243 #31058] FATAL -- : app/controllers/submissions_controller.rb:45:in `create'

```

## The problem
The problem is why the function invalidate_cache is doing an ```self.class.all(invalidate_cache: true)``` when doing a save or update.
In our case (at Agrportal) the ```self.class.all(invalidate_cache: true)``` for submissions take a lot of time than it causes a request time out.

## Our solution 

Add the option to not call to ```self.class.all(invalidate_cache: true)``` in the invalidate_cache
