### PR TITLE
Fix: unpin activesupport version (for Rails >= 6.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ontologies_api_client (2.0.3)
-      activesupport (= 6.0.4.1)
+      activesupport
       excon
       faraday
       faraday-excon (~> 2.0.0)
@@ -15,15 +15,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.4.1)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
-    excon (0.91.0)
+    concurrent-ruby (1.1.10)
+    excon (0.92.3)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -32,7 +31,7 @@ GEM
       faraday (~> 2.0.0.alpha.pre.2)
     faraday-multipart (1.0.3)
       multipart-post (>= 1.2, < 3)
-    faraday-net_http (2.0.1)
+    faraday-net_http (2.0.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     lz4-ruby (0.3.3)
@@ -40,7 +39,7 @@ GEM
     minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    oj (3.13.11)
+    oj (3.13.13)
     power_assert (2.0.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -50,10 +49,8 @@ GEM
     spawnling (2.1.5)
     test-unit (3.5.3)
       power_assert
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
-    zeitwerk (2.5.4)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "2.0.3"
 
-  gem.add_dependency('activesupport', '6.0.4.1')
+  gem.add_dependency('activesupport')
   gem.add_dependency('excon')
   gem.add_dependency('faraday')
   gem.add_dependency('faraday-excon', '~> 2.0.0')


### PR DESCRIPTION
The PR unpin the active support gem to be able to update the UI rails version from 6 to 6.1 (and then from 6.1 to 7)

requires ruby version >= 2.7.0