### PR TITLE
Fix: Return http delete, batch and patch responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PLATFORMS
   ruby
   x86_64-darwin-16
   x86_64-darwin-17
+  x86_64-linux
 
 DEPENDENCIES
   ontologies_api_client!

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -99,7 +99,7 @@ module LinkedData
         else
           responses = threaded_request(paths, params)
         end
-        return responses
+        responses
       end
 
       def self.post(path, obj, options = {})
@@ -133,12 +133,14 @@ module LinkedData
           custom_req(obj, file, file_attribute, req)
         end
         raise Exception, response.body if response.status >= 500
+        response
       end
 
       def self.delete(id)
         puts "Deleting #{id}" if $DEBUG
         response = conn.delete id
         raise Exception, response.body if response.status >= 500
+        response
       end
 
       def self.object_from_json(json)

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -19,6 +19,7 @@ class OpenStruct
   def length
     @table.keys.length
   end
+
   alias :size :length
 
   def to_a
@@ -37,7 +38,9 @@ end
 module LinkedData
   module Client
     module HTTP
-      class Link < String; attr_accessor :media_type; end
+      class Link < String
+        attr_accessor :media_type;
+      end
 
       def self.conn
         unless LinkedData::Client.connection_configured?
@@ -53,7 +56,7 @@ module LinkedData
       def self.get(path, params = {}, options = {})
         headers = options[:headers] || {}
         raw = options[:raw] || false # return the unparsed body of the request
-        params = params.delete_if {|k,v| v == nil || v.to_s.empty?}
+        params = params.delete_if { |k, v| v == nil || v.to_s.empty? }
         params[:ncbo_cache_buster] = Time.now.to_f if raw # raw requests don't get cached to ensure body is available
         invalidate_cache = params.delete(:invalidate_cache) || false
 
@@ -94,7 +97,7 @@ module LinkedData
         responses = []
         if conn.in_parallel?
           conn.in_parallel do
-            paths.each {|p| responses << conn.get(p, params) }
+            paths.each { |p| responses << conn.get(p, params) }
           end
         else
           responses = threaded_request(paths, params)
@@ -176,9 +179,11 @@ module LinkedData
 
       def self.params_file_handler(params)
         return if params.nil?
+
         file, return_attribute = nil, nil
         params.dup.each do |attribute, value|
           next unless value.is_a?(File) || value.is_a?(Tempfile) || value.is_a?(ActionDispatch::Http::UploadedFile)
+
           filename = value.original_filename
           file = Faraday::UploadIO.new(value.path, "text/plain", filename)
           return_attribute = attribute
@@ -209,7 +214,7 @@ module LinkedData
           context = json_obj.delete("@context") # strip context
 
           # Create a struct with the left-over attributes to store data
-          attributes = json_obj.keys.map {|k| k.to_sym}
+          attributes = json_obj.keys.map { |k| k.to_sym }
           attributes_always_present = value_cls.attrs_always_present || [] rescue []
           attributes = (attributes + attributes_always_present).uniq
 
@@ -239,7 +244,7 @@ module LinkedData
             end
           else
             # Get the struct class
-            recursive_obj_hash = {links: nil, context: nil}
+            recursive_obj_hash = { links: nil, context: nil }
             json_obj.each do |key, value|
               recursive_obj_hash[key] = recursive_struct(value)
             end
@@ -266,6 +271,7 @@ module LinkedData
 
         context = links.delete("@context")
         return if context.nil?
+
         links.keys.each do |link_type|
           link = Link.new(links[link_type])
           link.media_type = context[link_type]
@@ -276,6 +282,7 @@ module LinkedData
 
       def self.load_json(json)
         return if json.nil? || json.empty?
+
         begin
           MultiJson.load(json)
         rescue Exception => e

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -83,7 +83,7 @@ module LinkedData
           else
             obj = recursive_struct(load_json(response.body))
           end
-        rescue Exception => e
+        rescue StandardError => e
           puts "Problem getting #{path}" if $DEBUG
           raise e
         end
@@ -108,7 +108,8 @@ module LinkedData
           req.url path
           custom_req(obj, file, file_attribute, req)
         end
-        raise Exception, response.body if response.status >= 500
+        raise StandardError, response.body if response.status >= 500
+
         if options[:raw] || false # return the unparsed body of the request
           return response.body
         else
@@ -122,7 +123,8 @@ module LinkedData
           req.url path
           custom_req(obj, file, file_attribute, req)
         end
-        raise Exception, response.body if response.status >= 500
+        raise StandardError, response.body if response.status >= 500
+
         recursive_struct(load_json(response.body))
       end
 
@@ -132,14 +134,16 @@ module LinkedData
           req.url path
           custom_req(obj, file, file_attribute, req)
         end
-        raise Exception, response.body if response.status >= 500
+        raise StandardError, response.body if response.status >= 500
+
         response
       end
 
       def self.delete(id)
         puts "Deleting #{id}" if $DEBUG
         response = conn.delete id
-        raise Exception, response.body if response.status >= 500
+        raise StandardError, response.body if response.status >= 500
+
         response
       end
 

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -111,9 +111,9 @@ module LinkedData
         raise StandardError, response.body if response.status >= 500
 
         if options[:raw] || false # return the unparsed body of the request
-          return response.body
+          response.body
         else
-          return recursive_struct(load_json(response.body))
+          recursive_struct(load_json(response.body))
         end
       end
 


### PR DESCRIPTION
## The issue 
the `delete`, `batch`, and `patch` were returning nil and not the API response

### before (e.g delete)
``` ruby
 def self.delete(id)
        puts "Deleting #{id}" if $DEBUG
        response = conn.delete id
        raise StandardError, response.body if response.status >= 500
      end
```

### after  (e.g delete)

``` ruby
 def self.delete(id)
        puts "Deleting #{id}" if $DEBUG
        response = conn.delete id
        raise StandardError, response.body if response.status >= 500
       
        response
      end
```