### PR TITLE
Feature: Add the possibility to add a request id

### DIFF
--- a/lib/ontologies_api_client/link_explorer.rb
+++ b/lib/ontologies_api_client/link_explorer.rb
@@ -60,9 +60,15 @@ module LinkedData
         return url if values.nil? || values.empty?
         values = values.dup
         values = [values] unless values.is_a?(Array)
-        return url.gsub(/(\{.*?\})/) do
-          URI.escape(values.shift, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+        escaped_value = URI.escape(values.shift, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+        if url.match(/(\{.*?\})/)
+          url.gsub(/(\{.*?\})/) do
+            escaped_value
+          end
+        else
+          url + '/' + escaped_value
         end
+
       end
 
       def linkable_attributes


### PR DESCRIPTION
With this PR, you can do now something like this (for example I will take [FMA ontology](https://data.bioontology.org/ontologies/FMA))
```ruby
ontology.explore.submission(1) # will call https://data.bioontology.org/ontologies/FMA/submissions/1
```
or 
```ruby
ontology.explore.classes("http://purl.org/sig/ont/fma/fma65139") # will call https://data.bioontology.org/ontologies/FMA/classes/http%3A%2F%2Fpurl.org%2Fsig%2Font%2Ffma%2Ffma65139
```
(deprecating the `single_class: "https://data.bioontology.org/ontologies/FMA/classes/{class_id}"` link)

It may sound simple, but was not possible before (as far as I know)