### PR TITLE
Feautre: Add multiple media types models

### DIFF
--- a/lib/ontologies_api_client/base.rb
+++ b/lib/ontologies_api_client/base.rb
@@ -39,8 +39,11 @@ module LinkedData
         map = {}
         classes = LinkedData::Client::Models.constants.map {|c| LinkedData::Client::Models.const_get(c)}
         classes.each do |media_type_cls|
-          next if map[media_type_cls] || !media_type_cls.respond_to?(:media_type) || !media_type_cls.ancestors.include?(LinkedData::Client::Base)
-          map[media_type_cls.media_type] = media_type_cls
+          next if map[media_type_cls] || !media_type_cls.respond_to?(:media_types) || !media_type_cls.ancestors.include?(LinkedData::Client::Base)
+          media_type_cls.media_types.each do |type|
+            next if map[type]
+            map[type] = media_type_cls
+          end
           media_type_cls.act_as_media_type.each {|mt| map[mt] = media_type_cls} if media_type_cls.act_as_media_type
         end
         return map

--- a/lib/ontologies_api_client/base.rb
+++ b/lib/ontologies_api_client/base.rb
@@ -6,7 +6,15 @@ module LinkedData
       attr_accessor :context, :links
 
       class << self
-        attr_accessor :media_type, :act_as_media_type, :include_attrs, :include_attrs_full, :attrs_always_present
+        attr_accessor :act_as_media_type, :include_attrs, :include_attrs_full, :attrs_always_present
+        def media_types
+          Array(@media_type)
+        end
+
+        def media_type
+          media_types.first
+        end
+
       end
 
       ##

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -6,7 +6,7 @@ module LinkedData
     module Models
       class Class < LinkedData::Client::Base
         HTTP = LinkedData::Client::HTTP
-        @media_type = "http://www.w3.org/2002/07/owl#Class"
+        @media_type = %w[http://www.w3.org/2002/07/owl#Class http://www.w3.org/2004/02/skos/core#Concept]
         @include_attrs = "prefLabel,definition,synonym,obsolete,hasChildren"
         @include_attrs_full = "prefLabel,definition,synonym,obsolete,properties,hasChildren,children"
         @attrs_always_present = :prefLabel, :definition, :synonym, :obsolete, :properties, :hasChildren, :children


### PR DESCRIPTION
### Related

- https://github.com/ncbo/ontologies_linked_data/pull/162

### Goal
Show the correct type for skos:concept elements, like below 
![image](https://user-images.githubusercontent.com/29259906/202654790-58762fe3-c63b-488e-ab25-72b0ee7ae0c4.png)

### Issue
The issue is that currently  in this repository, each of our models contain a unique media_type, for example class.rb (representing ow:Class and skos:Concept) we have the following:
https://github.com/ncbo/ontologies_api_ruby_client/blob/master/lib/ontologies_api_client/models/class.rb#L7-L12

The media type of only ow:Class

### Solution
This PR: 

- Add the possibility to have multiple media types
- Add the media type skos:Concept for class.rb