### PR TITLE
Fix URI.escape is obsolete warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ontologies_api_client (2.2.0)
       activesupport (= 6.1.5.1)
+      addressable (~> 2.8)
       excon
       faraday
       faraday-excon (~> 2.0.0)
@@ -21,6 +22,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     excon (0.95.0)
@@ -45,6 +48,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.1)
     rake (13.0.6)
     ruby2_keywords (0.0.5)
     spawnling (2.1.5)

--- a/lib/ontologies_api_client/link_explorer.rb
+++ b/lib/ontologies_api_client/link_explorer.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'addressable/uri'
 require_relative 'http'
 
 module LinkedData
@@ -58,10 +58,11 @@ module LinkedData
 
       def replace_template_elements(url, values = [])
         return url if values.nil? || values.empty?
+
         values = values.dup
         values = [values] unless values.is_a?(Array)
         return url.gsub(/(\{.*?\})/) do
-          URI.escape(values.shift, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+          Addressable::URI.encode_component(values.shift, Addressable::URI::CharacterClasses::UNRESERVED)
         end
       end
 

--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require "uri"
 require_relative "../base"
 
@@ -47,8 +48,10 @@ module LinkedData
         def purl
           return "" if self.links.nil?
           return self.id if self.id.include?("purl.")
+
           ont = self.explore.ontology
-          "#{LinkedData::Client.settings.purl_prefix}/#{ont.acronym}?conceptid=#{URI.escape(self.id, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}"
+          encoded_id = Addressable::URI.encode_component(self.id, Addressable::URI::CharacterClasses::UNRESERVED)
+          "#{LinkedData::Client.settings.purl_prefix}/#{ont.acronym}?conceptid=#{encoded_id}"
         end
 
         def ontology

--- a/lib/ontologies_api_client/models/mapping.rb
+++ b/lib/ontologies_api_client/models/mapping.rb
@@ -1,4 +1,4 @@
-require "uri"
+require 'addressable/template'
 require_relative "../base"
 
 module LinkedData
@@ -11,11 +11,13 @@ module LinkedData
         @media_type = "http://data.bioontology.org/metadata/Mapping"
 
         def self.find(id, params = {})
-          HTTP.get(mappings_url_prefix + URI.escape(id, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")), params)
+          template = Addressable::Template.new("#{mappings_url_prefix}/{mapping}")
+          HTTP.get(template.expand({mapping: id}), params)
         end
 
         def delete
-          HTTP.delete(mappings_url_prefix + URI.escape(self.id, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")))
+          template = Addressable::Template.new("#{mappings_url_prefix}/{mapping}")
+          HTTP.delete(template.expand({mapping: self.id}))
         end
 
         private
@@ -24,7 +26,7 @@ module LinkedData
         # This is in a method because the settings are configured after
         # the VM initialization, so the rest_url could be null or wrong
         def self.mappings_url_prefix
-          LinkedData::Client.settings.rest_url + "/mappings/"
+          LinkedData::Client.settings.rest_url + "/mappings"
         end
 
         def mappings_url_prefix

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.version       = "2.2.0"
 
   gem.add_dependency('activesupport', '6.1.5.1')
+  gem.add_dependency('addressable', '~> 2.8')
   gem.add_dependency('excon')
   gem.add_dependency('faraday')
   gem.add_dependency('faraday-excon', '~> 2.0.0')


### PR DESCRIPTION
Fixes `URI.escape is obsolete` warnings that appeared after upgrading to Ruby 2.7. Also adds the addressable gem for improved handling of URIs.