### PR TITLE
Repair the 'find' method on LinkedData::Client::Models::Class

### DIFF
--- a/lib/ontologies_api_client/models/class.rb
+++ b/lib/ontologies_api_client/models/class.rb
@@ -60,7 +60,7 @@ module LinkedData
 
         def self.find(id, ontology, params = {})
           ontology = HTTP.get(ontology, params)
-          ontology.explore.class(URI.escape(id, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")))
+          ontology.explore.single_class(id)
         end
 
         def self.search(*args)

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -1,0 +1,16 @@
+require_relative '../test_case'
+
+class ClassTest < LinkedData::Client::TestCase
+  def test_find
+    id = 'http://bioontology.org/ontologies/Activity.owl#Activity'
+    ontology = 'https://data.bioontology.org/ontologies/BRO'
+    cls = LinkedData::Client::Models::Class.find(id, ontology)
+    refute_nil cls
+    assert_instance_of LinkedData::Client::Models::Class, cls
+    assert_equal id, cls.id
+    assert_equal 'http://www.w3.org/2002/07/owl#Class', cls.type
+    assert_equal 'Activity', cls.prefLabel
+    assert_equal ontology, cls.links['ontology']
+    assert_true cls.hasChildren
+  end
+end


### PR DESCRIPTION
Fixes the `find` method on `LinkedData::Client::Models::Class` that throws an ArgumentError. Also adds a new unit test file for `LinkedData::Client::Models::Class`.