### PR TITLE
Replace outdated test-unit with minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gemspec
 gem 'pry'
 gem 'rake'
 gem 'rubocop', '~> 1.43'
-gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    power_assert (2.0.3)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -75,8 +74,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     spawnling (2.1.5)
-    test-unit (3.5.7)
-      power_assert
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -90,11 +87,11 @@ PLATFORMS
 
 DEPENDENCIES
   faraday-follow_redirects (~> 0.3)
+  minitest (~> 5.18)
   ontologies_api_client!
   pry
   rake
   rubocop (~> 1.43)
-  test-unit
 
 BUNDLED WITH
    2.3.22

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('spawnling', '2.1.5')
 
   gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
+  gem.add_development_dependency('minitest', '~> 5.18')
 end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -14,7 +14,7 @@ class ClassTest < LinkedData::Client::TestCase
     assert_equal 'http://www.w3.org/2002/07/owl#Class', cls.type
     assert_equal 'Activity', cls.prefLabel
     assert_equal ontology, cls.links['ontology']
-    assert_true cls.hasChildren
+    assert cls.hasChildren
   end
 
   # Test PURL generation for a class in an OWL format ontology

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -20,13 +20,13 @@ class CollectionTest < LinkedData::Client::TestCase
   def test_class_for_type
     media_type = 'http://data.bioontology.org/metadata/Category'
     type_cls = LinkedData::Client::Base.class_for_type(media_type)
-    assert type_cls == LinkedData::Client::Models::Category
+    assert_equal LinkedData::Client::Models::Category, type_cls
   end
 
   def test_find_by
     bro = TestOntology.find_by_acronym('BRO')
     assert bro.length >= 1
-    assert bro.any? { |o| o.acronym.eql?('BRO') }
+    assert(bro.any? { |o| o.acronym.eql?('BRO') })
 
     onts = TestOntology.find_by_hasDomain_and_doNotUpdate('https://data.bioontology.org/categories/Health', true)
     assert onts.length >= 1
@@ -42,6 +42,6 @@ class CollectionTest < LinkedData::Client::TestCase
 
   def test_find
     ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
-    assert !ont.nil?
+    refute_nil ont
   end
 end

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -1,12 +1,14 @@
-require_relative '../test_case'
+# frozen_string_literal: true
+
 require 'pry'
+require_relative '../test_case'
 
 class TestOntology < LinkedData::Client::Base
   include LinkedData::Client::Collection
   include LinkedData::Client::ReadWrite
 
-  @media_type    = "http://data.bioontology.org/metadata/Ontology"
-  @include_attrs = "all"
+  @media_type    = 'http://data.bioontology.org/metadata/Ontology'
+  @include_attrs = 'all'
 end
 
 class CollectionTest < LinkedData::Client::TestCase
@@ -16,30 +18,30 @@ class CollectionTest < LinkedData::Client::TestCase
   end
 
   def test_class_for_type
-    media_type = "http://data.bioontology.org/metadata/Category"
+    media_type = 'http://data.bioontology.org/metadata/Category'
     type_cls = LinkedData::Client::Base.class_for_type(media_type)
     assert type_cls == LinkedData::Client::Models::Category
   end
 
   def test_find_by
-    bro = TestOntology.find_by_acronym("BRO")
+    bro = TestOntology.find_by_acronym('BRO')
     assert bro.length >= 1
-    assert bro.any? {|o| o.acronym.eql?("BRO")}
+    assert bro.any? { |o| o.acronym.eql?('BRO') }
 
-    onts = TestOntology.find_by_hasDomain_and_doNotUpdate("https://data.bioontology.org/categories/Health", true)
+    onts = TestOntology.find_by_hasDomain_and_doNotUpdate('https://data.bioontology.org/categories/Health', true)
     assert onts.length >= 1
 
-    onts = TestOntology.find_by_hasDomain_and_hasDomain("https://data.bioontology.org/categories/Phenotype", "https://data.bioontology.org/categories/Human")
+    onts = TestOntology.find_by_hasDomain_and_hasDomain('https://data.bioontology.org/categories/Phenotype', 'https://data.bioontology.org/categories/Human')
     assert onts.length >= 1
   end
 
   def test_where
-    onts = TestOntology.where {|o| o.name.downcase.start_with?("c")}
+    onts = TestOntology.where { |o| o.name.downcase.start_with?('c') }
     assert onts.length >= 1
   end
 
   def test_find
-    ont = TestOntology.find("https://data.bioontology.org/ontologies/SNOMEDCT")
+    ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
     assert !ont.nil?
   end
 end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../lib/ontologies_api_client'
 require_relative '../config/config'

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,10 +1,10 @@
-require 'test-unit'
+require 'minitest/autorun'
 require_relative '../lib/ontologies_api_client'
 require_relative '../config/config'
 
 module LinkedData
   module Client
-    class TestCase < Test::Unit::TestCase
+    class TestCase < Minitest::Test
     end
   end
 end


### PR DESCRIPTION
- Replaces test-unit with the [minitest](https://github.com/minitest/minitest) gem
- Refactors unit test code to use minitest
- Refactors tests to use more appropriate assertions
- Fixes some RuboCop warnings
- Resolves #20 