### PR TITLE
Adopt some optimizations implemented by LIRMM in 2023

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ontologies_api_client (2.3.0)
+    ontologies_api_client (2.4.0)
       activesupport (= 7.0.8)
       addressable (~> 2.8)
       excon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     logger (1.6.0)
     lz4-ruby (0.3.3)
     method_source (1.1.0)
-    minitest (5.24.1)
+    minitest (5.25.1)
     minitest-hooks (1.5.1)
       minitest (> 5.3)
     multi_json (1.15.0)
@@ -99,7 +99,7 @@ PLATFORMS
 
 DEPENDENCIES
   faraday-follow_redirects (~> 0.3)
-  minitest (~> 5.20)
+  minitest (~> 5.25)
   minitest-hooks (~> 1.5)
   ontologies_api_client!
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ PATH
       lz4-ruby
       multi_json
       oj
-      spawnling (= 2.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -84,7 +83,6 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    spawnling (2.1.5)
     strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/lib/ontologies_api_client.rb
+++ b/lib/ontologies_api_client.rb
@@ -1,6 +1,5 @@
 require 'oj'
 require 'multi_json'
-require 'spawnling'
 
 require_relative 'ontologies_api_client/config'
 require_relative 'ontologies_api_client/http'

--- a/lib/ontologies_api_client/collection.rb
+++ b/lib/ontologies_api_client/collection.rb
@@ -85,6 +85,8 @@ module LinkedData
         ##
         # Get a resource by id (this will retrieve it from the REST service)
         def get(id, params = {})
+          path = collection_path
+          id = "#{path}/#{id}" unless id.include?(path)
           HTTP.get(id, params)
         end
 

--- a/lib/ontologies_api_client/collection.rb
+++ b/lib/ontologies_api_client/collection.rb
@@ -73,13 +73,11 @@ module LinkedData
           end
         end
 
-        ##
         # Find a resource by id
+        #
+        # @deprecated Use {#get} instead
         def find(id, params = {})
-          found = where do |obj|
-            obj.id.eql?(id)
-          end
-          found.first
+          get(id, params)
         end
 
         ##

--- a/lib/ontologies_api_client/collection.rb
+++ b/lib/ontologies_api_client/collection.rb
@@ -25,7 +25,7 @@ module LinkedData
         ##
         # Get all top-level links for the API
         def top_level_links
-          HTTP.get(LinkedData::Client.settings.rest_url)
+          @top_level_links ||= HTTP.get(LinkedData::Client.settings.rest_url)
         end
 
         ##

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -61,7 +61,7 @@ module LinkedData
         invalidate_cache = params.delete(:invalidate_cache) || false
 
         begin
-          puts "Getting: #{path} with #{params}" if $DEBUG
+          puts "Getting: #{path} with #{params}" if $DEBUG_API_CLIENT
           begin
             response = conn.get do |req|
               req.url path
@@ -87,7 +87,7 @@ module LinkedData
             obj = recursive_struct(load_json(response.body))
           end
         rescue StandardError => e
-          puts "Problem getting #{path}" if $DEBUG
+          puts "Problem getting #{path}" if $DEBUG_API_CLIENT
           raise e
         end
         obj
@@ -143,7 +143,7 @@ module LinkedData
       end
 
       def self.delete(id)
-        puts "Deleting #{id}" if $DEBUG
+        puts "Deleting #{id}" if $DEBUG_API_CLIENT
         response = conn.delete id
         raise StandardError, response.body if response.status >= 500
 

--- a/lib/ontologies_api_client/http.rb
+++ b/lib/ontologies_api_client/http.rb
@@ -38,6 +38,8 @@ end
 module LinkedData
   module Client
     module HTTP
+      $DEBUG_API_CLIENT ||= false
+
       class Link < String
         attr_accessor :media_type;
       end

--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'cgi'
-require_relative "../base"
+require_relative '../base'
 
 module LinkedData
   module Client
@@ -8,19 +10,19 @@ module LinkedData
         include LinkedData::Client::Collection
         include LinkedData::Client::ReadWrite
 
-        @media_type = "http://data.bioontology.org/metadata/Ontology"
-        @include_attrs    = "all"
+        @media_type = 'http://data.bioontology.org/metadata/Ontology'
+        @include_attrs = 'all'
 
         def flat?
           self.flat
         end
 
         def private?
-          viewingRestriction && viewingRestriction.downcase.eql?("private")
+          viewingRestriction && viewingRestriction.downcase.eql?('private')
         end
 
         def licensed?
-          viewingRestriction && viewingRestriction.downcase.eql?("licensed")
+          viewingRestriction && viewingRestriction.downcase.eql?('licensed')
         end
 
         def viewing_restricted?
@@ -35,7 +37,7 @@ module LinkedData
           if self.acronym
             "#{LinkedData::Client.settings.purl_prefix}/#{acronym}"
           else
-            ""
+            ''
           end
         end
 
@@ -43,13 +45,13 @@ module LinkedData
           return true if !viewing_restricted?
           return false if user.nil?
           return true if user.admin?
-          return self.full_acl.any? {|u| u == user.id}
+          return self.full_acl.any? { |u| u == user.id }
         end
 
         def admin?(user)
           return false if user.nil?
           return true if user.admin?
-          return administeredBy.any? {|u| u == user.id}
+          return administeredBy.any? { |u| u == user.id }
         end
 
         def invalidate_cache(cache_refresh_all = true)
@@ -75,12 +77,12 @@ module LinkedData
         # Method to get the property tree for a given ontology
         # Gets the properties from the REST API and then returns a tree
         def property_tree
-          properties = Hash[self.explore.properties.map {|p| [p.id, p]}]
-          properties.keys.each do |key|
+          properties = Hash[self.explore.properties.map { |p| [p.id, p] }]
+          properties.each_key do |key|
             prop = properties[key]
-            prop.parents.each {|par| properties[par].children << prop if properties[par]}
+            prop.parents.each { |par| properties[par].children << prop if properties[par] }
           end
-          roots = properties.values.select {|p| p.parents.empty?}
+          roots = properties.values.select { |p| p.parents.empty? }
           root = LinkedData::Client::Models::Property.new
           root.children = roots
           root
@@ -97,7 +99,7 @@ module LinkedData
             params[:include_views] = params[:include_views] || true
           else
             # Stick params back and create a new one
-            args.push({include_views: true})
+            args.push({ include_views: true })
           end
           args.unshift(params)
           super(attrs, *args)
@@ -120,9 +122,8 @@ module LinkedData
         ##
         # Include parameters commonly used with ontologies
         def self.include_params
-          "acronym,administeredBy,group,hasDomain,name,notes,projects,reviews,summaryOnly,viewingRestriction"
+          'acronym,administeredBy,group,hasDomain,name,notes,projects,reviews,summaryOnly,viewingRestriction'
         end
-
       end
     end
   end

--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -54,11 +54,6 @@ module LinkedData
           return administeredBy.any? { |u| u == user.id }
         end
 
-        def invalidate_cache(cache_refresh_all = true)
-          self.class.all(invalidate_cache: true, include_views: true)
-          super(cache_refresh_all)
-        end
-
         # ACL with administrators
         def full_acl
           ((self.acl || []) + self.administeredBy).uniq

--- a/lib/ontologies_api_client/models/ontology.rb
+++ b/lib/ontologies_api_client/models/ontology.rb
@@ -108,9 +108,13 @@ module LinkedData
         # Override to search for views as well by default
         # Views get hidden on the REST service unless the `include_views`
         # parameter is set to `true`
-        def find(id, params = {})
+        def self.find(id, params = {})
           params[:include_views] = params[:include_views] || true
           super(id, params)
+        end
+
+        def self.find_by_acronym(acronym, params = {})
+          [find(acronym, params)]
         end
 
         ##

--- a/lib/ontologies_api_client/read_write.rb
+++ b/lib/ontologies_api_client/read_write.rb
@@ -91,16 +91,6 @@ module LinkedData
         session = Thread.current[:session]
         session[:last_updated] = Time.now.to_f if session
       end
-
-      def refresh_cache
-        Spawnling.new do
-          LinkedData::Client::Models::Ontology.all
-          LinkedData::Client::Models::OntologySubmission.all
-          LinkedData::Client::Models::User.all
-          exit
-        end
-      end
-
     end
   end
 end

--- a/lib/ontologies_api_client/read_write.rb
+++ b/lib/ontologies_api_client/read_write.rb
@@ -90,7 +90,6 @@ module LinkedData
         HTTP.get(self.id, invalidate_cache: true) if self.id
         session = Thread.current[:session]
         session[:last_updated] = Time.now.to_f if session
-        refresh_cache
       end
 
       def refresh_cache

--- a/lib/ontologies_api_client/version.rb
+++ b/lib/ontologies_api_client/version.rb
@@ -2,6 +2,6 @@
 
 module LinkedData
   module Client
-    VERSION = '2.3.0'
+    VERSION = '2.4.0'
   end
 end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('spawnling', '2.1.5')
 
   gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
-  gem.add_development_dependency('minitest', '~> 5.20')
+  gem.add_development_dependency('minitest', '~> 5.25')
   gem.add_development_dependency('minitest-hooks', '~> 1.5')
 end

--- a/ontologies_api_client.gemspec
+++ b/ontologies_api_client.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('lz4-ruby')
   gem.add_dependency('multi_json')
   gem.add_dependency('oj')
-  gem.add_dependency('spawnling', '2.1.5')
 
   gem.add_development_dependency('faraday-follow_redirects', '~> 0.3')
   gem.add_development_dependency('minitest', '~> 5.25')

--- a/test/models/test_collection.rb
+++ b/test/models/test_collection.rb
@@ -44,4 +44,18 @@ class CollectionTest < LinkedData::Client::TestCase
     ont = TestOntology.find('https://data.bioontology.org/ontologies/SNOMEDCT')
     refute_nil ont
   end
+
+  def test_get
+    ont = TestOntology.get('https://data.bioontology.org/ontologies/SNOMEDCT')
+    refute_nil ont
+    assert_instance_of LinkedData::Client::Models::Ontology, ont
+    assert_equal 'https://data.bioontology.org/ontologies/SNOMEDCT', ont.id
+    assert_equal 'SNOMEDCT', ont.acronym
+
+    ont = TestOntology.get('SNOMEDCT')
+    refute_nil ont
+    assert_instance_of LinkedData::Client::Models::Ontology, ont
+    assert_equal 'https://data.bioontology.org/ontologies/SNOMEDCT', ont.id
+    assert_equal 'SNOMEDCT', ont.acronym
+  end
 end

--- a/test/models/test_ontology.rb
+++ b/test/models/test_ontology.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../test_case'
+
+class OntologyTest < LinkedData::Client::TestCase
+  def test_find_by_acronym
+    result = LinkedData::Client::Models::Ontology.find_by_acronym('SNOMEDCT')
+    refute_empty result
+    assert_instance_of Array, result
+    assert_equal 1, result.length
+
+    ont = result.first
+    assert_instance_of LinkedData::Client::Models::Ontology, ont
+    assert_equal 'https://data.bioontology.org/ontologies/SNOMEDCT', ont.id
+    assert_equal 'SNOMEDCT', ont.acronym
+  end
+
+  def test_find
+    ont = LinkedData::Client::Models::Ontology.find('SNOMEDCT')
+    refute_nil ont
+    assert_instance_of LinkedData::Client::Models::Ontology, ont
+    assert_equal 'https://data.bioontology.org/ontologies/SNOMEDCT', ont.id
+    assert_equal 'SNOMEDCT', ont.acronym
+
+    ont = LinkedData::Client::Models::Ontology.find('BiositemapIM')
+    refute_nil ont
+    assert_instance_of LinkedData::Client::Models::Ontology, ont
+    assert_equal 'https://data.bioontology.org/ontologies/BiositemapIM', ont.id
+    assert_equal 'BiositemapIM', ont.acronym
+  end
+end


### PR DESCRIPTION
This pull request adopts some of the optimizations implemented by our LIRMM collaborators in their version of this library. The highlights include:

- Deprecate the `find` method in favor of `get`
- Modify the `get` method to add collection paths if not provided
- Stop refreshing the cache for all ontologies, submissions, and users when updating individual objects
- Cache the result of calls to `top_level_links` (the set of links never changes)

A more detailed explanation of these optimizations is available here: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14. The purpose of ingesting these optimizations now is part of a larger effort to address recent system instability in the BioPortal Ruby on Rails application: https://github.com/ncbo/bioportal-project/issues/320.

Also included in this pull request:

- Remove the no longer used `refresh_cache` method
- Remove the no longer used `spawnling` dependency
- Bump minitest from 5.24.1 to 5.25.1
- Fix some RuboCop warnings
